### PR TITLE
Use renderToPipeableStream wired up to a ReadableStream to add streaming support

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,2 @@
+# .env.dev
+NODE_ENV=development

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
     "dev": "vite",
     "build": "yarn build:client && yarn build:worker",
     "build:client": "vite build --outDir dist/client",
-    "build:worker": "WORKER=true vite build --outDir dist/worker --ssr worker.js",
+    "build:worker": "WORKER=true vite build --mode dev --outDir dist/worker --ssr worker.js",
     "serve": "vite preview",
     "workers": "miniflare dist/worker/worker.js -s dist/client"
   },
   "dependencies": {
     "@cloudflare/kv-asset-handler": "^0.1.3",
-    "react": "^18.0.0-beta-96ca8d915-20211115",
-    "react-dom": "^18.0.0-beta-96ca8d915-20211115",
+    "react": "18.0.0-beta-c1220ebdd-20211123",
+    "react-dom": "18.0.0-beta-c1220ebdd-20211123",
     "react-error-boundary": "^3.1.4"
   },
   "devDependencies": {

--- a/src/delays.js
+++ b/src/delays.js
@@ -16,7 +16,7 @@ export const ABORT_DELAY = 10000;
 
 // DIRTY DIRTY way to polyfill some missing globals in miniflare
 // There is a better way: https://miniflare.dev/api.html#arbitrary-bindings
-globalThis.setImmediate = globalThis.setImmediate || ((fn) => setTimeout(fn, 0));
+globalThis.setImmediate ||= fn => setTimeout(fn, 0);
 // We have this in Oxygen and can expose it
 globalThis.Buffer = globalThis.Buffer || {
     td: new TextEncoder(),

--- a/src/delays.js
+++ b/src/delays.js
@@ -13,3 +13,15 @@ export const API_DELAY = 2000;
 
 // How long the server waits for data before giving up.
 export const ABORT_DELAY = 10000;
+
+// DIRTY DIRTY way to polyfill some missing globals in miniflare
+// There is a better way: https://miniflare.dev/api.html#arbitrary-bindings
+globalThis.setImmediate = globalThis.setImmediate || ((fn) => setTimeout(fn, 0));
+// We have this in Oxygen and can expose it
+globalThis.Buffer = globalThis.Buffer || {
+    td: new TextEncoder(),
+    from: function(chunk) {
+        return this.td.encode(chunk);
+    }
+};
+// end dirty stuff

--- a/worker.js
+++ b/worker.js
@@ -34,7 +34,7 @@ addEventListener("fetch", (event) => {
   try {
     event.respondWith(renderInWorkers({ head }));
   } catch (error) {
-    return new Response(event.message, {
+    return new Response(error.message, {
       status: 500,
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1104,14 +1104,14 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-dom@^18.0.0-beta-96ca8d915-20211115:
-  version "18.0.0-beta-96ca8d915-20211115"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-beta-96ca8d915-20211115.tgz#511a754eddbb760c83d85251249fe9c52522326e"
-  integrity sha512-ISFQGQ0lHt+fz/Ch9K9coggTWzp9ScfuvzdshGJ73z5AI7mi9i6mVjVekMDnx0wiECjHP1s87rxNDQGGj9XnHw==
+react-dom@18.0.0-beta-c1220ebdd-20211123:
+  version "18.0.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.0.0-beta-c1220ebdd-20211123.tgz#e98d0e28cfc3665730b2a7abf00c087cdd41abeb"
+  integrity sha512-kY++te33IPgLbuRlVrm5uYrxla9y1lkW/icHNHD1zeSa4x0rKOqyW01HLBJPT6bN+PT89b98I5I/Qr0CXN+w6Q==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "0.21.0-beta-96ca8d915-20211115"
+    scheduler "0.21.0-beta-c1220ebdd-20211123"
 
 react-error-boundary@^3.1.4:
   version "3.1.4"
@@ -1125,10 +1125,10 @@ react-refresh@^0.10.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.10.0.tgz#2f536c9660c0b9b1d500684d9e52a65e7404f7e3"
   integrity sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==
 
-react@^18.0.0-beta-96ca8d915-20211115:
-  version "18.0.0-beta-96ca8d915-20211115"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-beta-96ca8d915-20211115.tgz#0b2a0cd808b85fdce987a0c254e0fab979a3828d"
-  integrity sha512-Io6qvToVSO1UWNWbJSH16gbgYTkseSbfpQvLaB7JPutt0QVvjpUlEE0nfmww77CFdawxGkyfm/x4zvNTlMkHsw==
+react@18.0.0-beta-c1220ebdd-20211123:
+  version "18.0.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.0.0-beta-c1220ebdd-20211123.tgz#1577d2e59dfde826e110074c5f20160e0c1d36d9"
+  integrity sha512-yP8Lvre7RS0TXFYEyRkijpaqilwM0kMG1iEkoIWgeNyjBDMeKjmqKDFCNtXoUca0WdJ0Y+DvmjKPce5XksJMaA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -1211,10 +1211,10 @@ sanitize-filename@^1.6.3:
   dependencies:
     truncate-utf8-bytes "^1.0.0"
 
-scheduler@0.21.0-beta-96ca8d915-20211115:
-  version "0.21.0-beta-96ca8d915-20211115"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-beta-96ca8d915-20211115.tgz#b15758da1f33734ab1219aa5147ea79037a42013"
-  integrity sha512-gm2zVVyjuIHlcqdAv57Tk/lFBf7+RDhYvIEaOZiKf3/YpIZbsiMnfy6yP6+VR3pS//V2LY5Mv8bf6fS+4IOWbg==
+scheduler@0.21.0-beta-c1220ebdd-20211123:
+  version "0.21.0-beta-c1220ebdd-20211123"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.21.0-beta-c1220ebdd-20211123.tgz#6a4c3cc426f4316e5f0df448b01e99b364aa7fc7"
+  integrity sha512-3qOlWLIx2gMB5FUgCuycE7vQhXyoTsy5VF9elrsXOSvpM7j4NMYYRf9ehjsllQK+8sSmmAlXHx/8kdcA500tdA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
This is a first MVP that uses `renderToPipeableStream` wired up to a `ReadableStream` instance.

Unlike directly using `renderToReadableStream`, this still streams (the throbber rotates on the page) but doesn't throw a stream close error and doesn't break HTML markup.