### PR TITLE
Use `bootstrapModules` from React Fizz Server

### DIFF
--- a/src/Html.jsx
+++ b/src/Html.jsx
@@ -9,13 +9,6 @@ export default function Html({ children, head }) {
           }}
         />
         {children}
-        {/*
-         * TODO: Fix Vite upstream to allow this tag to be injected via `bootstrapModules` in `pipeToWritableStream` instead.
-         * Currently, it breaks the JSX Runtime.
-         */}
-        {import.meta.env.DEV && (
-          <script type="module" src="/src/main.jsx"></script>
-        )}
       </body>
     </html>
   );

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -22,6 +22,7 @@ export function renderInNode({ res, head }) {
       <App head={head} />
     </DataProvider>,
     {
+      bootstrapModules: ["src/main.jsx"],
       onCompleteShell() {
         // If something errored before we started streaming, we set the error code appropriately.
         res.statusCode = didError ? 500 : 200;


### PR DESCRIPTION
This reproduces an error we see in the client when we use React's `bootstrapModules` approach to injecting the client entrypoint:

```
Html.jsx:6 Uncaught Error: @vitejs/plugin-react can't detect preamble. Something is wrong. See https://github.com/vitejs/vite-plugin-react/pull/11#discussion_r430879201
    at Html.jsx:6:11
(anonymous) @ Html.jsx:6
client.ts:52 
```

This is because React renders the entrypoint as `<script type="module" async>`. Since async scripts don't wait for anything else, the code executes, and the header of the file detects a missing preamble.

The preamble is still loaded, it just happens after the async script executes.